### PR TITLE
feat: add discord link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
     starlight({
       title: 'Vim Korea',
       social: {
+        discord: 'https://discord.com/widget?id=1071395189219938354&theme=dark',
         github: 'https://github.com/vim-kr/renewal',
       },
       sidebar: [


### PR DESCRIPTION
기존 vim.kr의 위젯링크 사용
https://github.com/vim-kr/vim-kr.github.io/blob/main/docs/src/index.md 