### PR TITLE
커뮤니티 소개 섹션 초안 작성

### DIFF
--- a/src/components/about-section.astro
+++ b/src/components/about-section.astro
@@ -1,20 +1,105 @@
 ---
-import { Card, CardGrid } from '@astrojs/starlight/components'
+/* eslint-disable */
+import GlassMorphicCard from 'components/glass-morphic-card.astro'
 ---
 
-<h1>Next steps</h1>
+<div class="py-10
+	px-10
+	grid
+	gap-x-10
+	grid-cols-1
+	md:grid-cols-2">
+    <div class="introduction">
+        <GlassMorphicCard colorVariant="blue">
+            <Fragment slot="title">Vim에 대한 애정</Fragment>
+            <p>Vim에 대한 애정이 넘쳐나는 사람들을 위한 따뜻한 커뮤니티</p>
+        </GlassMorphicCard>
 
-<CardGrid stagger>
-    <Card title="Update content" icon="pencil">
-        Edit `src/content/docs/index.mdx` to see this page change.
-    </Card>
-    <Card title="Add new content" icon="add-document">
-        Add Markdown or MDX files to `src/content/docs` to create new pages.
-    </Card>
-    <Card title="Configure your site" icon="setting">
-        Edit your `sidebar` and other config in `astro.config.mjs`.
-    </Card>
-    <Card title="Read the docs" icon="open-book">
-        Learn more in [the Starlight Docs](https://starlight.astro.build/).
-    </Card>
-</CardGrid>
+        <GlassMorphicCard colorVariant="red">
+            <Fragment slot="title">
+                언제든지 도움을 요청할 수 있는 커뮤니티
+            </Fragment>
+            <p>
+                vim.kr은 초보자부터 플러그인 개발자 및 10년 이상 써온 전문가까지
+                다양한 전문성을 가진 사람들이 모인 커뮤니티입니다.
+            </p>
+        </GlassMorphicCard>
+
+        <GlassMorphicCard colorVariant="yellow">
+            <Fragment slot="title">다양한 배경의 개발자가 모인 멜팅팟</Fragment>
+            <p>
+                vim.kr은 웹/모바일/SRE/이공계 연구원 등 Vim을 사용하는 다양한
+                배경을 가진 사람들이 모인 멜팅팟입니다.
+            </p>
+        </GlassMorphicCard>
+        <div class="discord-invitation-button">
+            <div
+                class="flex
+		justify-center
+		md:justify-start
+		items-center
+		mt-12
+		md:mt-8"
+            >
+                <a
+                    href="https://discord.gg/FCDhM2cw65"
+                    class="flex
+		items-center
+		bg-white
+		border
+		border-gray-300
+		rounded-lg
+		shadow-md
+		cursor-pointer
+		px-6
+		py-4
+		text-sm
+		font-medium
+		text-gray-800
+		hover:bg-gray-200
+		focus:outline-none
+		focus:ring-2
+		focus:ring-offset-2
+		focus:ring-gray-500"
+                >
+                    <svg
+                        class="h-6 w-6 mr-2"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                        width="800px"
+                        height="800px"
+                        viewBox="0 -28.5 256 256"
+                        version="1.1"
+                        preserveAspectRatio="xMidYMid"
+                    >
+                        <g>
+                            <path
+                                d="M216.856339,16.5966031 C200.285002,8.84328665 182.566144,3.2084988 164.041564,0 C161.766523,4.11318106 159.108624,9.64549908 157.276099,14.0464379 C137.583995,11.0849896 118.072967,11.0849896 98.7430163,14.0464379 C96.9108417,9.64549908 94.1925838,4.11318106 91.8971895,0 C73.3526068,3.2084988 55.6133949,8.86399117 39.0420583,16.6376612 C5.61752293,67.146514 -3.4433191,116.400813 1.08711069,164.955721 C23.2560196,181.510915 44.7403634,191.567697 65.8621325,198.148576 C71.0772151,190.971126 75.7283628,183.341335 79.7352139,175.300261 C72.104019,172.400575 64.7949724,168.822202 57.8887866,164.667963 C59.7209612,163.310589 61.5131304,161.891452 63.2445898,160.431257 C105.36741,180.133187 151.134928,180.133187 192.754523,160.431257 C194.506336,161.891452 196.298154,163.310589 198.110326,164.667963 C191.183787,168.842556 183.854737,172.420929 176.223542,175.320965 C180.230393,183.341335 184.861538,190.991831 190.096624,198.16893 C211.238746,191.588051 232.743023,181.531619 254.911949,164.955721 C260.227747,108.668201 245.831087,59.8662432 216.856339,16.5966031 Z M85.4738752,135.09489 C72.8290281,135.09489 62.4592217,123.290155 62.4592217,108.914901 C62.4592217,94.5396472 72.607595,82.7145587 85.4738752,82.7145587 C98.3405064,82.7145587 108.709962,94.5189427 108.488529,108.914901 C108.508531,123.290155 98.3405064,135.09489 85.4738752,135.09489 Z M170.525237,135.09489 C157.88039,135.09489 147.510584,123.290155 147.510584,108.914901 C147.510584,94.5396472 157.658606,82.7145587 170.525237,82.7145587 C183.391518,82.7145587 193.761324,94.5189427 193.539891,108.914901 C193.539891,123.290155 183.391518,135.09489 170.525237,135.09489 Z"
+                                fill="#5865F2"
+                                fill-rule="nonzero"
+                            >
+                            </path>
+                        </g>
+                    </svg>
+
+                    <span>디스코드 서버에 참여하기</span>
+                </a>
+            </div>
+        </div>
+    </div>
+    <div
+        class="vim-logo
+		flex
+		justify-center
+		md:justify-end
+		align-start
+		order-first
+		md:order-last
+		mb-12"
+    >
+        <img
+            style="max-width: 15rem; max-height: 15rem; width: 100%; object-fit: contain;"
+            src="https://cdn.freebiesupply.com/logos/large/2x/vim-logo-png-transparent.png"
+        />
+    </div>
+</div>

--- a/src/components/about-section.astro
+++ b/src/components/about-section.astro
@@ -1,0 +1,20 @@
+---
+import { Card, CardGrid } from '@astrojs/starlight/components'
+---
+
+<h1>Next steps</h1>
+
+<CardGrid stagger>
+    <Card title="Update content" icon="pencil">
+        Edit `src/content/docs/index.mdx` to see this page change.
+    </Card>
+    <Card title="Add new content" icon="add-document">
+        Add Markdown or MDX files to `src/content/docs` to create new pages.
+    </Card>
+    <Card title="Configure your site" icon="setting">
+        Edit your `sidebar` and other config in `astro.config.mjs`.
+    </Card>
+    <Card title="Read the docs" icon="open-book">
+        Learn more in [the Starlight Docs](https://starlight.astro.build/).
+    </Card>
+</CardGrid>

--- a/src/components/glass-morphic-card.astro
+++ b/src/components/glass-morphic-card.astro
@@ -1,0 +1,56 @@
+---
+interface Props {
+    colorVariant: 'gray' | 'green' | 'red' | 'blue' | 'yellow' | 'violet'
+}
+
+const { colorVariant = 'green' } = Astro.props
+
+const backgroundColors = {
+    gray: 'bg-gray-100',
+    green: 'bg-green-100',
+    red: 'bg-red-100',
+    blue: 'bg-blue-100',
+    yellow: 'bg-yellow-100',
+    violet: 'bg-violet-100',
+}
+
+const borderColors = {
+    gray: 'border-gray-300',
+    green: 'border-green-300',
+    red: 'border-red-300',
+    blue: 'border-blue-300',
+    yellow: 'border-yellow-300',
+    violet: 'border-violet-300',
+}
+
+const backgroundColor = backgroundColors[colorVariant]
+const borderColor = borderColors[colorVariant]
+---
+
+<div
+    className={`
+  w-full
+  ${backgroundColor}
+  ${borderColor} 
+  px-6
+  py-10
+  rounded-2xl
+  bg-clip-padding 
+  backdrop-filter 
+  backdrop-blur-md 
+  bg-opacity-40
+  border-opacity-40
+  border
+`}
+>
+    <h2 style="word-break: keep-all;">
+        <slot name="icon" />
+        <slot name="title" />
+    </h2>
+    <div
+        style="word-break: keep-all;"
+        class="text-2xl text-slate-800 leading-10"
+    >
+        <slot />
+    </div>
+</div>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -16,21 +16,6 @@ hero:
           icon: external
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components'
+import AboutSection from 'components/about-section.astro'
 
-## Next steps
-
-<CardGrid stagger>
-    <Card title="Update content" icon="pencil">
-        Edit `src/content/docs/index.mdx` to see this page change.
-    </Card>
-    <Card title="Add new content" icon="add-document">
-        Add Markdown or MDX files to `src/content/docs` to create new pages.
-    </Card>
-    <Card title="Configure your site" icon="setting">
-        Edit your `sidebar` and other config in `astro.config.mjs`.
-    </Card>
-    <Card title="Read the docs" icon="open-book">
-        Learn more in [the Starlight Docs](https://starlight.astro.build/).
-    </Card>
-</CardGrid>
+<AboutSection />


### PR DESCRIPTION
context: [[WEB-2a]](https://discord.com/channels/1071395189219938354/1192736344879923211) 

메인페이지 중 최상단에 표시되는 커뮤니티 소개 섹션의 초안 버전을 작업했습니다.

## 와이어프레임 (참고)

![vim-kr-renewal](https://github.com/vim-kr/renewal/assets/2427963/6a4d9227-c560-4ce9-8ded-816ea329dcb7)

## 실제 UI

![스크린샷 2024-01-06 06-26-20](https://github.com/vim-kr/renewal/assets/2427963/363a6068-2609-4315-803b-c5084bfb5324)
