### PR TITLE
AboutSection 컴포넌트 스타일링

### DIFF
--- a/src/components/about-section.astro
+++ b/src/components/about-section.astro
@@ -85,7 +85,8 @@ import GlassMorphicCard from 'components/glass-morphic-card.astro'
                         </g>
                     </svg>
 
-                    <span>디스코드 서버에 참여하기</span>
+                    <span style="color: #5865F2;">디스코드 서버에 참여하기</span
+                    >
                 </a>
             </div>
         </div>

--- a/src/components/about-section.astro
+++ b/src/components/about-section.astro
@@ -3,13 +3,16 @@
 import GlassMorphicCard from 'components/glass-morphic-card.astro'
 ---
 
-<div class="grid
+<div
+    style="background-image: url('https://storage.googleapis.com/memedex-bucket/general-purpose/screenshot-neovim.png'); object-fit: cover;"
+    class="grid
 	grid-cols-1
 	gap-x-10
 	px-10
 	py-10
-	md:grid-cols-2">
-    <div class="introduction">
+	md:grid-cols-3"
+>
+    <div class="introduction col-span-1 md:col-span-2">
         <GlassMorphicCard colorVariant="blue">
             <Fragment slot="title">Vim에 대한 애정</Fragment>
             <p>Vim에 대한 애정이 넘쳐나는 사람들을 위한 따뜻한 커뮤니티</p>
@@ -91,6 +94,7 @@ import GlassMorphicCard from 'components/glass-morphic-card.astro'
         class="vim-logo
 		align-start
 		order-first
+		col-span-1
 		mb-12
 		flex
 		justify-center

--- a/src/components/glass-morphic-card.astro
+++ b/src/components/glass-morphic-card.astro
@@ -44,13 +44,13 @@ const borderColor = borderColors[colorVariant]
   backdrop-filter
 `}
 >
-    <h2 style="word-break: keep-all;">
+    <h2 style="word-break: keep-all;" class="!text-slate-300">
         <slot name="icon" />
         <slot name="title" />
     </h2>
     <div
         style="word-break: keep-all;"
-        class="text-2xl leading-10 text-slate-800"
+        class="text-2xl leading-10 !text-slate-300"
     >
         <slot />
     </div>

--- a/src/components/glass-morphic-card.astro
+++ b/src/components/glass-morphic-card.astro
@@ -30,6 +30,7 @@ const borderColor = borderColors[colorVariant]
 <div
     class={`
   w-full
+  max-w-2xl
   ${backgroundColor}
   ${borderColor} 
   rounded-2xl

--- a/src/components/glass-morphic-card.astro
+++ b/src/components/glass-morphic-card.astro
@@ -34,9 +34,9 @@ const borderColor = borderColors[colorVariant]
   ${backgroundColor}
   ${borderColor} 
   rounded-2xl
-  border
+  border-4
   border-opacity-40
-  bg-opacity-40 
+  bg-opacity-30 
   bg-clip-padding 
   px-6 
   py-10

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,3 +2,11 @@ main > .content-panel:first-of-type {
     /* 기본적으로 생기는 title 영역 제거 */
     display: none;
 }
+
+.sl-container {
+	max-width: 100% !important;
+}
+
+.content-panel {
+	padding: 0 !important;
+}


### PR DESCRIPTION
# Overview
* GlassMorphicCard 컴포넌트 단독으로는 정상적으로 동작하는지 파악하기 어려운 관계로 샘플 이미지를 임시로 넣었습니다.
* GlassMorphicCard 컴포넌트가 AboutSection 안에서는 1:1 grid보다는 2:1 grid로 표시되는 쪽이 좀 더 UI적으로 깔끔하기 때문에 grid layout을 수정했습니다.

## 데스크탑 화면
| before  | after    |
|--------------- | --------------- |
| ![스크린샷 2024-01-10 02-11-16](https://github.com/vim-kr/renewal/assets/2427963/f139ec80-58c4-44ac-b44c-2a466ab36d53) | ![스크린샷 2024-01-10 02-11-09](https://github.com/vim-kr/renewal/assets/2427963/5e3e19e9-2fc1-475a-8d94-a302f420ae4c)   |


## 모바일 화면
| before  | after    |
|--------------- | --------------- |
| ![스크린샷 2024-01-10 01-56-59](https://github.com/vim-kr/renewal/assets/2427963/dd26e757-4d0c-4b22-85a1-a417cb4f821b)   | ![스크린샷 2024-01-10 01-56-48](https://github.com/vim-kr/renewal/assets/2427963/a6d82663-93b8-4a92-a017-44cfbf74e3e6)   |