### PR TITLE
GlassMorphicCard 컴포넌트의 가독성 개선

### DIFF
--- a/src/components/glass-morphic-card.astro
+++ b/src/components/glass-morphic-card.astro
@@ -42,6 +42,8 @@ const borderColor = borderColors[colorVariant]
   py-10
   backdrop-blur-md
   backdrop-filter
+  shadow-md
+  shadow-black
 `}
 >
     <h2


### PR DESCRIPTION
각 카드의 제목에 text-stroke 속성을 추가하고, 색상을 white로 변경하여 좀 더 강조되는 효과를 주었고,
박스 컴포넌트 자체에 box-shadow 속성을 적용하여 좀 더 양감이 있는 시각적 효과를 적용하였습니다.

결과적으로 GlassMorphicCard 컴포넌트가 좀 더 시각적으로 드러나보이도록 개선했습니다.

| Before | After |
|--------|--------|
| ![스크린샷 2024-01-17 03-54-18](https://github.com/vim-kr/renewal/assets/2427963/3dd0f989-bf0b-4c94-b509-8a8fd29d2ab6) | ![스크린샷 2024-01-17 03-54-25](https://github.com/vim-kr/renewal/assets/2427963/43637e66-34f2-40b9-ac32-48c81b427854) |