### PR TITLE
chore: 유저 케이스 Tab UI 간단수정

### DIFF
--- a/src/components/container.astro
+++ b/src/components/container.astro
@@ -2,6 +2,6 @@
 
 ---
 
-<div class="px-4 md:px-10">
+<div class="px-4 pt-[80px] md:px-10">
     <slot />
 </div>

--- a/src/components/usecase-section/usecase-label.jsx
+++ b/src/components/usecase-section/usecase-label.jsx
@@ -1,7 +1,7 @@
 const UsecaseLabel = ({ isActive = false, children }) => {
     return (
         <div
-            className={`!m-0 cursor-pointer rounded-2xl px-6 py-10 text-6xl font-extrabold text-gray-600
+            className={`!m-0 cursor-pointer rounded-2xl py-10 text-6xl font-extrabold text-gray-600
 			  ${
                   isActive
                       ? 'text-white'

--- a/src/components/usecase-section/usecase-rounded-label.jsx
+++ b/src/components/usecase-section/usecase-rounded-label.jsx
@@ -1,7 +1,7 @@
 const UsecaseRoundedLabel = ({ isActive = false, children }) => {
     return (
         <div
-            className={`!md:none !m-0 flex h-20 w-20 cursor-pointer items-center justify-center rounded-full bg-gray-300 text-3xl font-extrabold text-gray-400 hover:bg-white hover:text-black ${
+            className={`!md:none !m-0 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-gray-300 text-3xl font-extrabold text-gray-400 hover:bg-white hover:text-black ${
                 isActive ? 'bg-white !text-black' : ''
             }`}
         >

--- a/src/components/usecase-section/usecase-selection.jsx
+++ b/src/components/usecase-section/usecase-selection.jsx
@@ -25,7 +25,7 @@ const UsecaseSelection = () => {
 
     return (
         <div>
-            <div className="block px-6 md:hidden">
+            <div className="block md:hidden">
                 <div className="flex gap-x-6">
                     {usecases.map((usecase, index) => (
                         <div


### PR DESCRIPTION
- tab 사이즈 수정 : 모바일(375px)에서 tab이 영역 약간 넘어가는 케이스
- margin 제거 : 왼쪽 정렬맞추기 위해서 x축 마진 제거

| before | after |
|--------|--------|
| ![image](https://github.com/vim-kr/renewal/assets/142373285/47ccce8f-6bbb-4557-9fdc-ca355611212b) | ![image](https://github.com/vim-kr/renewal/assets/142373285/7c297ea5-5888-4fdc-96c8-4d1a0fd6c712) |

