### PR TITLE
feat: main 페이지 style 정리, neovim news 섹션 추가

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,6 +33,12 @@ export default defineConfig({
             directory: 'note-taking',
           },
         },
+        {
+          label: 'Neovim News',
+          autogenerate: {
+            directory: 'neovim-news',
+          },
+        },
       ],
     }),
     tailwind(),

--- a/src/components/usecase-section/usecase-label.jsx
+++ b/src/components/usecase-section/usecase-label.jsx
@@ -1,7 +1,7 @@
 const UsecaseLabel = ({ isActive = false, children }) => {
     return (
         <div
-            className={`!m-0 cursor-pointer rounded-2xl py-10 text-6xl font-extrabold text-gray-600
+            className={`!m-0 cursor-pointer rounded-2xl py-10 text-4xl font-extrabold text-gray-600
 			  ${
                   isActive
                       ? '!text-blue-500 dark:!text-white'

--- a/src/components/usecase-section/usecase-rounded-label.jsx
+++ b/src/components/usecase-section/usecase-rounded-label.jsx
@@ -1,7 +1,7 @@
 const UsecaseRoundedLabel = ({ isActive = false, children }) => {
     return (
         <div
-            className={`!md:none !m-0 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-gray-300 text-3xl font-extrabold text-gray-400 hover:bg-white hover:text-black ${
+            className={`!md:none !m-0 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-gray-300 text-2xl font-extrabold text-gray-400 hover:bg-white hover:text-black ${
                 isActive ? 'bg-white !text-black' : ''
             }`}
         >

--- a/src/components/usecase-section/usecase-selection.jsx
+++ b/src/components/usecase-section/usecase-selection.jsx
@@ -7,23 +7,27 @@ import UsecaseDescription from './usecase-description'
 const usecaseMetadata = {
     ['getting-started']: {
         headline: 'Getting started',
-        description: 'vim의 기본기능에 대해서 알아보자',
+        description: 'vim의 기본기능 보러가기',
         route: '/getting-started/how-to-vim',
+        icon: <i class="fa-solid fa-shoe-prints"></i>,
     },
     ['vim-as-ide']: {
         headline: 'Vim as IDE',
-        description: 'vim을 어떻게 하면 IDE처럼 사용하는 방법에 대해 알아보자',
+        description: 'vim을 환경을 IDE로 사용하기',
         route: '/vim-as-ide/kickstart',
+        icon: <i class="fa-solid fa-rocket"></i>,
     },
     ['note-taking']: {
         headline: 'Note taking',
-        description: 'vim을 어떻게 하면 노트 테이킹에 활용할 수 있을까',
+        description: 'vim을 노트 테이킹에 활용하기',
         route: '/note-taking/vimwiki',
+        icon: <i class="fa-regular fa-pen-to-square"></i>,
     },
-    ['vim-as-tui']: {
-        headline: 'Vim as TUI',
-        description: 'vim을 어떻게 하면 TUI로 활용할 수 있을까',
-        route: '/',
+    ['neovim-news']: {
+        headline: 'Neovim News',
+        description: 'Neovim 관련 업데이트 내용 보러가기',
+        route: '/neovim-news/inspect',
+        icon: <i class="fa-solid fa-newspaper"></i>,
     },
 }
 
@@ -36,7 +40,7 @@ const UsecaseSelection = () => {
         <div>
             <div className="block md:hidden">
                 <div className="flex gap-x-6">
-                    {usecases.map((usecase, index) => (
+                    {usecases.map((usecase) => (
                         <div
                             className="!m-0"
                             onClick={() => selectUsecase(usecase)}
@@ -44,7 +48,7 @@ const UsecaseSelection = () => {
                             <UsecaseRoundedLabel
                                 isActive={usecase === activeUsecase}
                             >
-                                {index + 1}
+                                {usecaseMetadata[usecase]['icon']}
                             </UsecaseRoundedLabel>
                         </div>
                     ))}
@@ -54,6 +58,7 @@ const UsecaseSelection = () => {
                 const isActive = usecase === activeUsecase
                 return (
                     <div
+                        className="!mt-0"
                         onClick={() => {
                             selectUsecase(usecase)
                         }}

--- a/src/content/docs/neovim-news/inspect.md
+++ b/src/content/docs/neovim-news/inspect.md
@@ -1,0 +1,12 @@
+---
+title: Neovim support Inspect for Treesitter
+description: Neovim support Inspect for Treesitter
+---
+
+## `:Inspect`로 highlight 확인하기
+
+기존에 nvim-treesitter의 [playground 플러그인][1]에서 제공하던 기능을 neovim이 내장하게 되었다.
+:Inspect 명령어로 현재 커서위치의 highlight 정보를 볼 수 있다.
+playground repo는 public archive가 되었다.
+
+[1]: https://github.com/nvim-treesitter/playground


### PR DESCRIPTION
## 스타일
- tab index에 icon 적용
- neovim news 섹션 추가 (tui는 컨텐츠가 없어서 제거함)

## 문서
- neovim news로 inspect 관련내용 관련하여 간략하게 문서생성

![image](https://github.com/vim-kr/renewal/assets/61320923/82c92d07-de14-4f56-b462-965a277c9b55)
