### PR TITLE
style: limit main container width

### DIFF
--- a/src/components/container.astro
+++ b/src/components/container.astro
@@ -2,6 +2,6 @@
 
 ---
 
-<div class="px-4 pt-[40px] md:px-10">
+<div class="main-container m-auto px-4 pt-[40px] md:px-10">
     <slot />
 </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,3 +16,8 @@ main > .content-panel:first-of-type {
 .dark-text-stroke {
     -webkit-text-stroke: 1px #9e9e9e;
 }
+
+.main-container {
+    /* PC 환경에서 최대 1440px로 제한 */
+    width: min(100%, 1440px);
+}


### PR DESCRIPTION
## Feat

- PC 환경에서 시선분산이 많이 되어서 최대 너비를 1440px로 조정함

| before | after |
|--------|--------|
| ![image](https://github.com/vim-kr/renewal/assets/61320923/d22558b2-caf8-4cd7-af26-7dd99f89bd6e) | ![image](https://github.com/vim-kr/renewal/assets/61320923/88ae58e9-3876-4990-ba1d-fc3b154b597f) | 