### PR TITLE
Hide header and link elements in page

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,3 +21,15 @@ main > .content-panel:first-of-type {
     /* PC 환경에서 최대 1440px로 제한 */
     width: min(100%, 1440px);
 }
+
+div.page > header.header {
+	display: none;
+}
+
+body > a { 
+	display: none;
+}
+
+.main-frame {
+	padding-top: 0;
+}


### PR DESCRIPTION
랜딩페이지의 가독성을 위해 상단의 NavBar를 숨김처리 했습니다.