### PR TITLE
메인페이지의 Vim 로고에 비쥬얼 효과 적용

### DIFF
--- a/src/components/about-section.astro
+++ b/src/components/about-section.astro
@@ -98,7 +98,7 @@ import GlassMorphicCard from 'components/glass-morphic-card.astro'
 		md:justify-end"
     >
         <img
-            style="max-width: 15rem; max-height: 15rem; width: 100%; object-fit: contain;"
+            style="max-width: 20rem; max-height: 20rem; width: 100%; object-fit: contain; transform: skew(-15deg, 5deg); filter: drop-shadow(3rem 2rem 1rem #222); margin-bottom: 5rem"
             src="https://cdn.freebiesupply.com/logos/large/2x/vim-logo-png-transparent.png"
         />
     </div>


### PR DESCRIPTION
# As-is
![스크린샷 2024-03-06 02-11-58](https://github.com/vim-kr/renewal/assets/2427963/55ebacde-00e7-4c34-9e4a-a1b7ebcd917c)

# To-be
![스크린샷 2024-03-06 02-11-05](https://github.com/vim-kr/renewal/assets/2427963/6b82e392-62ae-4e34-a85f-2c8b80f9ba81)

메인 페이지 상단의 Vim 로고 이미지가 기존에는 평면적이고 밋밋한 느낌이었다면,
기울임 효과 및 shadow 필터를 적용하여 좀 더 입체감이 있고 강조된 느낌을 살렸습니다.